### PR TITLE
account_journal_lock_date: no need to inherit write()

### DIFF
--- a/account_journal_lock_date/models/account_move.py
+++ b/account_journal_lock_date/models/account_move.py
@@ -10,11 +10,6 @@ class AccountMove(models.Model):
 
     _inherit = "account.move"
 
-    def write(self, values):
-        res = super().write(values)
-        self._check_fiscalyear_lock_date()
-        return res
-
     def _check_fiscalyear_lock_date(self):
         res = super()._check_fiscalyear_lock_date()
         if self.env.context.get("bypass_journal_lock_date"):


### PR DESCRIPTION
This is a forward port of PR https://github.com/OCA/account-financial-tools/pull/1459

In v16, the write() of account.move now checks that "name" of account.move cannot be changed in a locked period, cf
https://github.com/odoo/odoo/blob/16.0/addons/account/models/account_move.py#L2202
so no need to inherit write() at all any more in this module.