### PR TITLE
[11.0][FIX] account_spread_cost_revenue and account_document_reversal

### DIFF
--- a/account_document_reversal/models/account_move.py
+++ b/account_document_reversal/models/account_move.py
@@ -16,7 +16,7 @@ class AccountMove(models.Model):
     @api.multi
     def button_cancel(self):
         """ Do not allow using this button for cancel with reversal """
-        cancel_reversal = all(self.mapped('is_cancel_reversal'))
+        cancel_reversal = self and all(self.mapped('is_cancel_reversal'))
         if cancel_reversal:
             raise ValidationError(
                 _('This action is not allowed for cancel with reversal.\n'

--- a/account_document_reversal/tests/test_invoice_reversal.py
+++ b/account_document_reversal/tests/test_invoice_reversal.py
@@ -78,3 +78,8 @@ class TestInvoiceReversal(SavepointCase):
         self.assertTrue(reversed_move_reconcile)
         self.assertEqual(move_reconcile, reversed_move_reconcile)
         self.assertEqual(self.invoice.state, 'cancel')
+
+    def test_button_cancel_empty_recordset(self):
+        """button_cancel on empty recordset should not raise."""
+        empty_moves = self.env['account.move']
+        empty_moves.button_cancel()

--- a/account_spread_cost_revenue/models/account_invoice.py
+++ b/account_spread_cost_revenue/models/account_invoice.py
@@ -38,8 +38,9 @@ class AccountInvoice(models.Model):
         res = super().action_cancel()
         spread_lines = self.mapped('invoice_line_ids.spread_id.line_ids')
         moves = spread_lines.mapped('move_id')
-        moves.button_cancel()
-        moves.unlink()
+        if moves:
+            moves.button_cancel()
+            moves.unlink()
         spread_lines.unlink()
         return res
 

--- a/account_spread_cost_revenue/tests/test_account_invoice_spread.py
+++ b/account_spread_cost_revenue/tests/test_account_invoice_spread.py
@@ -768,3 +768,11 @@ class TestAccountInvoiceSpread(common.TransactionCase):
         # Invoice lines do not contain the lint to the spread.
         refund = self.invoice.refund_invoice_ids[0]
         self.assertFalse(refund.invoice_line_ids.mapped('spread_id'))
+
+    def test_16_cancel_invoice_without_spread(self):
+        """Cancel invoice without spread lines should not raise."""
+        self.invoice.journal_id.write({'update_posted': True})
+        self.invoice.action_invoice_open()
+        self.assertEqual(self.invoice.state, 'open')
+        self.invoice.action_invoice_cancel()
+        self.assertEqual(self.invoice.state, 'cancel')


### PR DESCRIPTION
`account_document_reversal — models/account_move.py`                                                                                                                                            
                                                                                                                                                                                                            
  Bug: button_cancel() llamado sobre un recordset vacío lanza ValidationError incorrectamente porque all([]) devuelve True en Python.                                                                       
                                                                                                                                                                                                            
  Fix: Añadir guard self and antes de all(...) para cortocircuitar en recordset vacío.                                                                                                                      
                  
  ---                                                                                                                                                                                                       
`  account_spread_cost_revenue — models/account_invoice.py`
                                                         
  Bug: Al cancelar una factura sin spread lines, moves es un recordset vacío y se llama moves.button_cancel() sin comprobación, disparando el bug anterior.
                                                                                                                                                                                                            
  Fix: Añadir if moves: antes de button_cancel() y unlink(), consistente con el patrón de Odoo base en action_cancel().                                                                                     
                                                                                                                                                                                                            
  ---                                                                                                                                                                                                       
  Root cause: La combinación de ambos módulos provoca que cancelar cualquier factura sin spread lines falle con el error "This action is not allowed for cancel with reversal. Please use Reverse Entry",
  independientemente de la configuración del diario.