### PR TITLE
[FIX] account_spread_cost_revenue: excluir cuentas de balance

### DIFF
--- a/account_spread_cost_revenue/i18n/account_spread_cost_revenue.pot
+++ b/account_spread_cost_revenue/i18n/account_spread_cost_revenue.pot
@@ -772,3 +772,16 @@ msgstr ""
 msgid "e.g. Template cleaning contract"
 msgstr ""
 
+#. module: account_spread_cost_revenue
+#: model:ir.model.fields,help:account_spread_cost_revenue.field_res_company_spread_no_analytic_on_balance
+msgid ""
+"If enabled, spread journal entries keep the analytic account and tags only "
+"on profit & loss lines, never on balance-sheet lines (accounts whose type "
+"carries the initial balance forward)."
+msgstr ""
+
+#. module: account_spread_cost_revenue
+#: model:ir.model.fields,field_description:account_spread_cost_revenue.field_res_company_spread_no_analytic_on_balance
+msgid "No analytic on balance accounts"
+msgstr ""
+

--- a/account_spread_cost_revenue/i18n/es.po
+++ b/account_spread_cost_revenue/i18n/es.po
@@ -818,3 +818,19 @@ msgid ""
 msgstr ""
 "El cuadro de distribución seleccionado está en %s pero la factura está en "
 "%s. Vincula un cuadro con la misma moneda o crea uno nuevo."
+
+#. module: account_spread_cost_revenue
+#: model:ir.model.fields,help:account_spread_cost_revenue.field_res_company_spread_no_analytic_on_balance
+msgid ""
+"If enabled, spread journal entries keep the analytic account and tags only "
+"on profit & loss lines, never on balance-sheet lines (accounts whose type "
+"carries the initial balance forward)."
+msgstr ""
+"Si se activa, los asientos de periodificación mantienen la cuenta analítica "
+"y las etiquetas solo en las líneas de pérdidas y ganancias, nunca en las "
+"líneas de cuentas de balance (cuentas cuyo tipo arrastra el saldo inicial)."
+
+#. module: account_spread_cost_revenue
+#: model:ir.model.fields,field_description:account_spread_cost_revenue.field_res_company_spread_no_analytic_on_balance
+msgid "No analytic on balance accounts"
+msgstr "Sin analítica en cuentas de balance"

--- a/account_spread_cost_revenue/models/account_spread_line.py
+++ b/account_spread_cost_revenue/models/account_spread_line.py
@@ -111,6 +111,9 @@ class AccountInvoiceSpreadLine(models.Model):
             'amount_currency': not_same_curr and - 1.0 * self.amount or 0.0,
         })]
 
+        if spread.company_id.spread_no_analytic_on_balance:
+            self._remove_analytic_from_balance_lines(line_ids)
+
         return {
             'name': '/',
             'ref': self.name,
@@ -119,6 +122,25 @@ class AccountInvoiceSpreadLine(models.Model):
             'line_ids': line_ids,
             'company_id': spread.company_id.id,
         }
+
+    @api.multi
+    def _remove_analytic_from_balance_lines(self, line_ids):
+        """Strip the analytic account and tags from balance-sheet move lines.
+
+        The spread move debits/credits one P&L account and one balance-sheet
+        account. Analytic accounting (cost centers) only makes sense on the
+        P&L line, so balance-sheet lines must not carry it. Balance accounts
+        are identified by ``include_initial_balance`` on their account type.
+        """
+        for command in line_ids:
+            line_vals = command[2]
+            if not line_vals.get('analytic_account_id'):
+                continue
+            account = self.env['account.account'].browse(
+                line_vals['account_id'])
+            if account.user_type_id.include_initial_balance:
+                line_vals['analytic_account_id'] = False
+                line_vals['analytic_tag_ids'] = [(5, 0, 0)]
 
     @api.multi
     def open_move(self):

--- a/account_spread_cost_revenue/models/res_company.py
+++ b/account_spread_cost_revenue/models/res_company.py
@@ -31,3 +31,10 @@ class ResCompany(models.Model):
         'Auto-archive spread',
         help="Enable this option if you want the cron job to automatically "
              "archive the spreads when all lines are posted.")
+    spread_no_analytic_on_balance = fields.Boolean(
+        'No analytic on balance accounts',
+        default=True,
+        help="If enabled, spread journal entries keep the analytic account "
+             "and tags only on profit & loss lines, never on balance-sheet "
+             "lines (accounts whose type carries the initial balance "
+             "forward).")

--- a/account_spread_cost_revenue/readme/CONFIGURE.rst
+++ b/account_spread_cost_revenue/readme/CONFIGURE.rst
@@ -21,3 +21,10 @@ enable/disable the automatic posting by the flag *Auto-post lines* present in th
 
 On the form view of the company, enable the *Auto-archive spread* option if you want the
 cron job to automatically archive the spreads when all lines are posted.
+
+On the form view of the company, the *No analytic on balance accounts* option (enabled by
+default) keeps the analytic account and analytic tags only on the profit & loss lines of the
+spread journal entries, removing them from the balance-sheet lines (accounts whose type carries
+the initial balance forward). Disable it to restore the previous behaviour, where the analytic
+account is set on every line of the entry. Note that the option only affects entries generated
+after it is changed; previously posted entries are not recomputed.

--- a/account_spread_cost_revenue/tests/__init__.py
+++ b/account_spread_cost_revenue/tests/__init__.py
@@ -3,3 +3,4 @@
 from . import test_account_spread_cost_revenue
 from . import test_compute_spread_board
 from . import test_account_invoice_spread
+from . import test_spread_no_analytic_on_balance

--- a/account_spread_cost_revenue/tests/test_account_invoice_spread.py
+++ b/account_spread_cost_revenue/tests/test_account_invoice_spread.py
@@ -20,6 +20,11 @@ class TestAccountInvoiceSpread(common.TransactionCase):
         super().setUp()
         self._load('account', 'test', 'account_minimal_test.xml')
 
+        # Keep the legacy behaviour (analytic on every spread move line) for
+        # this suite. The opt-out default (no analytic on balance accounts) is
+        # covered in test_spread_no_analytic_on_balance.py.
+        self.env.user.company_id.spread_no_analytic_on_balance = False
+
         type_receivable = self.env.ref('account.data_account_type_receivable')
         type_payable = self.env.ref('account.data_account_type_payable')
         type_revenue = self.env.ref('account.data_account_type_revenue')

--- a/account_spread_cost_revenue/tests/test_spread_no_analytic_on_balance.py
+++ b/account_spread_cost_revenue/tests/test_spread_no_analytic_on_balance.py
@@ -1,0 +1,122 @@
+# Copyright 2026 FactorLibre
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.modules.module import get_module_resource
+from odoo.tests import common
+from odoo.tools import convert_file
+
+
+class TestSpreadNoAnalyticOnBalance(common.TransactionCase):
+    def _load(self, module, *args):
+        convert_file(
+            self.cr,
+            'account_spread_cost_revenue',
+            get_module_resource(module, *args),
+            {}, 'init', False, 'test', self.registry._assertion_report)
+
+    def setUp(self):
+        super().setUp()
+        self._load('account', 'test', 'account_minimal_test.xml')
+
+        self.company = self.env.user.company_id
+
+        # P&L accounts (include_initial_balance == False)
+        self.expense_account = self.env.ref(
+            'account_spread_cost_revenue.a_expense')
+        self.income_account = self.env.ref(
+            'account_spread_cost_revenue.a_sale')
+        # Balance-sheet account (include_initial_balance == True), e.g. 480
+        self.balance_account = self.env.ref(
+            'account_spread_cost_revenue.prepayements')
+        self.journal = self.env.ref(
+            'account_spread_cost_revenue.miscellaneous_journal')
+
+        # Guard the fixture assumptions the whole suite relies on.
+        self.assertFalse(
+            self.expense_account.user_type_id.include_initial_balance)
+        self.assertFalse(
+            self.income_account.user_type_id.include_initial_balance)
+        self.assertTrue(
+            self.balance_account.user_type_id.include_initial_balance)
+
+        self.analytic_account = self.env['account.analytic.account'].create({
+            'name': 'Test cost center',
+        })
+        self.analytic_tag = self.env.ref('analytic.tag_contract')
+
+    def _create_spread(self, invoice_type, debit_account, credit_account):
+        spread = self.env['account.spread'].create({
+            'name': 'test spread',
+            'invoice_type': invoice_type,
+            'debit_account_id': debit_account.id,
+            'credit_account_id': credit_account.id,
+            'period_number': 12,
+            'period_type': 'month',
+            'spread_date': '2026-01-01',
+            'estimated_amount': 1200.0,
+            'journal_id': self.journal.id,
+            'account_analytic_id': self.analytic_account.id,
+            'analytic_tag_ids': [(6, 0, self.analytic_tag.ids)],
+        })
+        spread.compute_spread_board()
+        return spread
+
+    def _assert_split(self, move):
+        """P&L lines keep the analytic data; balance lines must not."""
+        self.assertTrue(move.line_ids)
+        for ml in move.line_ids:
+            if ml.account_id.user_type_id.include_initial_balance:
+                self.assertFalse(
+                    ml.analytic_account_id,
+                    'Balance line should not carry an analytic account')
+                self.assertFalse(
+                    ml.analytic_tag_ids,
+                    'Balance line should not carry analytic tags')
+            else:
+                self.assertEqual(ml.analytic_account_id, self.analytic_account)
+                self.assertEqual(ml.analytic_tag_ids, self.analytic_tag)
+
+    def test_01_cost_spread_default_strips_balance_analytic(self):
+        # Default behaviour (flag enabled): debit expense (P&L),
+        # credit prepaid (balance).
+        self.assertTrue(self.company.spread_no_analytic_on_balance)
+        spread = self._create_spread(
+            'in_invoice', self.expense_account, self.balance_account)
+        line = spread.line_ids[0]
+        line.create_move()
+        self.assertTrue(line.move_id)
+        self._assert_split(line.move_id)
+
+    def test_02_revenue_spread_default_strips_balance_analytic(self):
+        # Revenue spread: debit deferred income (balance), credit income (P&L).
+        spread = self._create_spread(
+            'out_invoice', self.balance_account, self.income_account)
+        line = spread.line_ids[0]
+        line.create_move()
+        self.assertTrue(line.move_id)
+        self._assert_split(line.move_id)
+
+    def test_03_flag_off_keeps_analytic_on_all_lines(self):
+        # Opt-out: legacy behaviour keeps analytic on every line, balance too.
+        self.company.spread_no_analytic_on_balance = False
+        spread = self._create_spread(
+            'in_invoice', self.expense_account, self.balance_account)
+        line = spread.line_ids[0]
+        line.create_move()
+        self.assertTrue(line.move_id)
+        balance_lines = line.move_id.line_ids.filtered(
+            lambda ml: ml.account_id == self.balance_account)
+        self.assertTrue(balance_lines)
+        for ml in line.move_id.line_ids:
+            self.assertEqual(ml.analytic_account_id, self.analytic_account)
+            self.assertEqual(ml.analytic_tag_ids, self.analytic_tag)
+
+    def test_04_refund_spread_strips_balance_analytic(self):
+        # The discriminator is account-driven, so refunds behave like the
+        # base invoice: the balance line never carries analytic data.
+        spread = self._create_spread(
+            'in_refund', self.expense_account, self.balance_account)
+        line = spread.line_ids[0]
+        line.create_move()
+        self.assertTrue(line.move_id)
+        self._assert_split(line.move_id)

--- a/account_spread_cost_revenue/views/res_company.xml
+++ b/account_spread_cost_revenue/views/res_company.xml
@@ -24,6 +24,7 @@
                         <group name="spreading_options_right">
                             <field name="force_move_auto_post"/>
                             <field name="auto_archive"/>
+                            <field name="spread_no_analytic_on_balance"/>
                         </group>
                     </group>
                 </page>


### PR DESCRIPTION
En las periodificaciones (`account_spread_cost_revenue`), la cuenta analítica (CECO) y las etiquetas analíticas se mantienen **solo en los apuntes de PyG**, nunca en los de cuenta de balance (identificados por `account.account.user_type_id.include_initial_balance`).

Se añade el check de compañía **`spread_no_analytic_on_balance`** (activo por defecto), en *Compañía → Account Spread*. Desactivable por compañía para recuperar el comportamiento anterior (CECO en ambos apuntes).
